### PR TITLE
replace deprecated `sudo` with `become`

### DIFF
--- a/tasks/certificate-file.yml
+++ b/tasks/certificate-file.yml
@@ -33,6 +33,7 @@
     mode:   "{{ papertrail_rsyslog_tls_cert_bundle_mode }}"
     owner:  "{{ papertrail_rsyslog_tls_cert_bundle_owner }}"
     group:  "{{ papertrail_rsyslog_tls_cert_bundle_group  }}"
+  become: true
 
 - set_fact:
     papertrail_rsyslog_tls_cert_bundle_do_not_use_var: yes

--- a/tasks/certificate-file.yml
+++ b/tasks/certificate-file.yml
@@ -5,7 +5,7 @@
     url: "{{ papertrail_rsyslog_tls_cert_bundle_url }}"
     dest: "{{ papertrail_rsyslog_tls_cert_bundle_download_path }}"
   delegate_to: 127.0.0.1
-  sudo: no
+  become: no
 
 - name: Stat the bundle
   stat:
@@ -15,7 +15,7 @@
   register: papertrail_rsyslog_tls_cert_bundle_download
   delegate_to: 127.0.0.1
   run_once: true
-  sudo: no
+  become: no
 
 - name: Compare the bundle variable now to the checksum to save copying to the server
   fail:

--- a/tasks/certificate-var.yml
+++ b/tasks/certificate-var.yml
@@ -22,4 +22,5 @@
     mode:   "{{ papertrail_rsyslog_tls_cert_bundle_mode }}"
     owner:  "{{ papertrail_rsyslog_tls_cert_bundle_owner }}"
     group:  "{{ papertrail_rsyslog_tls_cert_bundle_group  }}"
+  become: true
 ...

--- a/tasks/certificate-var.yml
+++ b/tasks/certificate-var.yml
@@ -5,7 +5,7 @@
     return_content: yes
   delegate_to: 127.0.0.1
   run_once: true
-  sudo: no
+  become: no
   register: papertrail_rsyslog_tls_cert_bundle_result
   when: papertrail_rsyslog_tls_cert_bundle is not defined
 

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -5,12 +5,14 @@
     name: rsyslog-gnutls
     state: "{{ 'latest' if papertrail_pkg_mgr_install_latest else 'present' }}"
   when: ansible_pkg_mgr == 'apt' and papertrail_install_rsyslog_gnutls
+  become: true
 
 - name: Ensure rsyslog-gnutls is installed on CentOS flavours
   yum:
     name: rsyslog-gnutls
     state: "{{ 'latest' if papertrail_pkg_mgr_install_latest else 'present' }}"
   when: ansible_pkg_mgr == 'yum' and papertrail_install_rsyslog_gnutls
+  become: true
 
 - include: certificate-file.yml
   when: papertrail_rsyslog_tls_cert_bundle_download_path is defined
@@ -25,6 +27,7 @@
     path: "{{ papertrail_rsyslog_tls_cert_bundle_path }}"
   register: papertrail_rsyslog_tls_cert_bundle_stat
   when: papertrail_rsyslog_tls_cert_bundle_checksum is defined
+  become: true
 
 - name: Check the checksum against the stat
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     state: "{{ 'latest' if papertrail_pkg_mgr_install_latest else 'present' }}"
     update_cache: "{{ papertrail_pkg_mgr_update_cache }}"
   when: ansible_pkg_mgr == 'apt' and papertrail_install_rsyslog
+  become: true
 
 - name: Ensure rsyslog is installed on CentOS flavours
   yum:
@@ -12,6 +13,7 @@
     state: "{{ 'latest' if papertrail_pkg_mgr_install_latest else 'present' }}"
     update_cache: "{{ papertrail_pkg_mgr_update_cache }}"
   when: ansible_pkg_mgr == 'yum' and papertrail_install_rsyslog
+  become: true
 
 - name: Make the rsyslog.d directory
   file:
@@ -21,6 +23,7 @@
     owner: "{{ papertrail_rsyslogd_conf_dir_owner }}"
     group: "{{ papertrail_rsyslogd_conf_dir_group }}"
     recurse: "{{ papertrail_rsyslogd_conf_dir_recurse }}"
+  become: true
 
 - name: Copy the template into place
   template:
@@ -32,6 +35,7 @@
   when: papertrail_rsyslog_conf_file_template is defined
   notify:
     - restart rsyslog
+  become: true
 
 
 - name: Ensure the rsyslog.d directory is included
@@ -59,6 +63,7 @@
   when: papertrail_rsyslog_work_dir is defined
   notify:
     - restart rsyslog
+  become: true
 
 - name: Put the papertrail config into the rsyslog.d directory
   template:
@@ -69,5 +74,6 @@
     group: "{{ papertrail_rsyslogd_file_group  }}"
   notify:
     - restart rsyslog
+  become: true
 
 ...

--- a/test/vagrant/ubuntu/Trusty
+++ b/test/vagrant/ubuntu/Trusty
@@ -21,6 +21,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "playbook.yml"
     ansible.verbose = 'vv'
-    ansible.sudo = true
+    ansible.become = true
   end
 end


### PR DESCRIPTION
resolve this deprecation warning:
```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default).
This feature will be removed in a future
```
--
The use of `become` is needed if you are provisioning using an Admin user (enabled to run `sudo`), especially useful when root ssh access is disallowed

An example case is when re-provisioning a vm which had the `root` access disabled after the first provisioning and had access managed via JumpCloud tags/users
